### PR TITLE
Run dns server on all IP addresses

### DIFF
--- a/lib/olodum.js
+++ b/lib/olodum.js
@@ -132,7 +132,7 @@ exports.start = function (callback) {
   dnsServer = dnsd.createServer(mainListener);
 
   log('Starting process ' + process.pid);
-  dnsServer.listen(53,'127.0.0.1', function () {
+  dnsServer.listen(53, function () {
     log('Olodum listening on port 53');
     log('Olodum forwarding domains ' + domains.join(', ') + ' to ' + target);
     that.started = true;


### PR DESCRIPTION
This allows us to use test devices accessing our development stacks running applications where a specific hostname is needed by the application server. 

Would you be willing to consider it?

An alternative would be to allow an argument on the command line that sets the running IP address.

Thanks for the great tool!

Paul
